### PR TITLE
Add tests for config parsing and directory walking

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func TestNewConfigFromCommand(t *testing.T) {
+	tmp := t.TempDir()
+	output := filepath.Join(tmp, "out.xml")
+
+	var cfg *Config
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "output"},
+			&cli.BoolFlag{Name: "force"},
+			&cli.BoolFlag{Name: "no-tree"},
+			&cli.BoolFlag{Name: "no-sort"},
+			&cli.BoolFlag{Name: "ignore-secrets"},
+			&cli.BoolFlag{Name: "redact-secrets"},
+			&cli.BoolFlag{Name: "skip-token-count"},
+			&cli.StringFlag{Name: "format"},
+			&cli.IntFlag{Name: "high-token-threshold"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			cfg = NewConfigFromCommand(c)
+			return nil
+		},
+	}
+
+	args := []string{
+		"cmd", tmp,
+		"--output", output,
+		"--force",
+		"--no-tree",
+		"--no-sort",
+		"--ignore-secrets",
+		"--redact-secrets",
+		"--skip-token-count",
+		"--format", "xml",
+		"--high-token-threshold", "9000",
+	}
+	if err := cmd.Run(context.Background(), args); err != nil {
+		t.Fatalf("run command: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatalf("config not set")
+	}
+
+	if cfg.TargetDir != tmp {
+		t.Errorf("target dir: got %s want %s", cfg.TargetDir, tmp)
+	}
+	if cfg.OutputFile != output {
+		t.Errorf("output: got %s want %s", cfg.OutputFile, output)
+	}
+	if !cfg.Force {
+		t.Errorf("force not set")
+	}
+	if cfg.ShowTree {
+		t.Errorf("show tree should be false")
+	}
+	if !cfg.DisableSort {
+		t.Errorf("disable sort not set")
+	}
+	if cfg.Format != "xml" {
+		t.Errorf("format got %s", cfg.Format)
+	}
+	if !cfg.IgnoreSecrets || !cfg.RedactSecrets {
+		t.Errorf("secret flags not set")
+	}
+	if !cfg.SkipTokenCount {
+		t.Errorf("skip token count not set")
+	}
+	if cfg.HighTokenThreshold != 9000 {
+		t.Errorf("high token threshold got %d", cfg.HighTokenThreshold)
+	}
+	if cfg.LargeFileSizeThreshold != DefaultLargeFileSizeThreshold {
+		t.Errorf("large file size threshold mismatch")
+	}
+	if !cfg.AllowedFileExtensions[".go"] {
+		t.Errorf("expected .go in allowed extensions")
+	}
+	if len(cfg.IgnoredPathRegexes) != len(DefaultIgnoredPathPatterns) {
+		t.Errorf("regex count mismatch")
+	}
+	if !cfg.ShouldWriteFile() {
+		t.Errorf("ShouldWriteFile expected true")
+	}
+}
+
+func TestCompileRegexesInvalid(t *testing.T) {
+	_, err := compileRegexes([]string{"["})
+	if err == nil {
+		t.Fatalf("expected error for invalid regex")
+	}
+}

--- a/internal/core/walker_test.go
+++ b/internal/core/walker_test.go
@@ -1,0 +1,76 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// helper to create file with contents
+func createFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestDefaultWalker_Walk(t *testing.T) {
+	tmp := t.TempDir()
+
+	// create files and directories
+	createFile(t, filepath.Join(tmp, "file1.go"))
+	createFile(t, filepath.Join(tmp, "skipme.go"))
+	createFile(t, filepath.Join(tmp, "not_allowed.txt"))
+	createFile(t, filepath.Join(tmp, "output.md"))
+
+	// directory excluded via .grimoireignore
+	exclDir := filepath.Join(tmp, "excluded_dir")
+	createFile(t, filepath.Join(exclDir, "c.go"))
+
+	// subdir with gitignore rule
+	subdir := filepath.Join(tmp, "subdir1")
+	createFile(t, filepath.Join(subdir, "a.go"))
+	createFile(t, filepath.Join(subdir, "ignored.go"))
+	createFile(t, filepath.Join(subdir, "nested", "b.go"))
+
+	// directory ignored via regex
+	createFile(t, filepath.Join(tmp, "skip_dir", "d.go"))
+
+	// write ignore files
+	os.WriteFile(filepath.Join(tmp, ".grimoireignore"), []byte("excluded_dir/\n"), 0o644)
+	os.WriteFile(filepath.Join(subdir, ".gitignore"), []byte("ignored.go\n"), 0o644)
+
+	allowed := map[string]bool{".go": true}
+	regexes := []*regexp.Regexp{
+		regexp.MustCompile(`skip_dir`),
+		regexp.MustCompile(`^skipme\.go$`),
+	}
+
+	dw := NewDefaultWalker(tmp, allowed, regexes, filepath.Join(tmp, "output.md"))
+	files, err := dw.Walk()
+	if err != nil {
+		t.Fatalf("walk error: %v", err)
+	}
+
+	expected := map[string]bool{
+		"file1.go": true,
+		filepath.ToSlash(filepath.Join("subdir1", "a.go")):           true,
+		filepath.ToSlash(filepath.Join("subdir1", "nested", "b.go")): true,
+	}
+	if len(files) != len(expected) {
+		t.Fatalf("expected %d files, got %d: %v", len(expected), len(files), files)
+	}
+	for _, f := range files {
+		if !expected[f] {
+			t.Errorf("unexpected file %s", f)
+		}
+		delete(expected, f)
+	}
+	for k := range expected {
+		t.Errorf("missing expected file %s", k)
+	}
+}


### PR DESCRIPTION
## Summary
- test config parsing via `NewConfigFromCommand`
- test regex compilation failure
- add directory walker unit test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840672a78a88325884150592f01ee0c